### PR TITLE
add dependencies for chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           name: Install Dependencies
           command: |
             yarn
-            sudo apt install xvfb libxtst6 libxss1 libgtk2.0-0 -y
+            sudo apt install libxtst6 libxss1 libgtk-3-0 -y
             sudo apt install libnss3 libasound2 libgconf-2-4 -y
       - run:
           name: Test opening nteract desktop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,10 @@ jobs:
 
       - run:
           name: Install Dependencies
-          command: yarn
+          command: |
+            yarn
+            sudo apt install xvfb libxtst6 libxss1 libgtk2.0-0 -y
+            sudo apt install libnss3 libasound2 libgconf-2-4 -y
       - run:
           name: Test opening nteract desktop
           command: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,13 @@ jobs:
             yarn
             sudo apt install libxtst6 libxss1 libgtk-3-0 -y
             sudo apt install libnss3 libasound2 libgconf-2-4 -y
+
       - run:
           name: Test opening nteract desktop
-          command: yarn test
+          command: |
+            sudo Xvfb :99 -ac &
+            export DISPLAY=:99
+            yarn test
             
 
 


### PR DESCRIPTION
At the moment, spectron is timing out. It seems that it could be related to chrome driver dependencies, so we are checking that out here.