### PR TITLE
simplify CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8
+      - image: circleci/node:8.11.4-browsers
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -22,6 +22,7 @@ jobs:
       - run:
           name: Install nteract desktop
           command: |
+            sudo apt install libgif-dev
             git clone git@github.com:nteract/nteract.git
             cd nteract
             yarn
@@ -32,16 +33,11 @@ jobs:
 
       - run:
           name: Install Dependencies
-          command: |
-            yarn
-            sudo apt install libxtst6 libxss1 libgtk-3-0 -y
-            sudo apt install libnss3 libasound2 libgconf-2-4 -y
+          command: yarn
 
       - run:
           name: Test opening nteract desktop
           command: |
-            sudo Xvfb :99 -ac &
-            export DISPLAY=:99
             yarn test
             
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,9 @@ app
     // Stop the application
     return app.stop();
   })
+  .then(function() {
+    console.log("Success!");
+  })
   .catch(function(error) {
     // Log any failures
     console.error("Test failed", error.message);


### PR DESCRIPTION
As noted by @rgbkrk in #2, by switching out our docker image we can simplify our CI setup 🙂